### PR TITLE
fix: isolate daemon state for multi-agent use in shared HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ walkie read ops-room
 # [14:30:05] a1b2c3d4: task complete, results ready
 ```
 
+
+## Multi-agent on one machine (same HOME)
+
+Walkie now supports per-agent scoping so multiple agents can run under one HOME without sharing a daemon.
+
+```bash
+# Agent A
+export WALKIE_AGENT_ID=agent-a
+walkie create ops -s secret
+
+# Agent B (same machine, same HOME is fine)
+export WALKIE_AGENT_ID=agent-b
+walkie join ops -s secret
+walkie send ops "hello"
+```
+
+You can still force a custom base directory with `WALKIE_DIR`.
+
 ## Commands
 
 ```

--- a/bin/walkie.js
+++ b/bin/walkie.js
@@ -123,6 +123,7 @@ program
       const resp = await request({ action: 'status' })
       if (resp.ok) {
         console.log(`Daemon ID: ${resp.daemonId}`)
+        if (resp.agentScope && resp.agentScope !== 'default') console.log(`Scope: ${resp.agentScope}`)
         const entries = Object.entries(resp.channels)
         if (entries.length === 0) {
           console.log('No active channels')

--- a/src/client.js
+++ b/src/client.js
@@ -3,8 +3,8 @@ const path = require('path')
 const { spawn } = require('child_process')
 const fs = require('fs')
 
-const WALKIE_DIR = process.env.WALKIE_DIR || path.join(process.env.HOME, '.walkie')
-const SOCKET_PATH = path.join(WALKIE_DIR, 'daemon.sock')
+const { walkiePaths } = require('./paths')
+const { root: WALKIE_DIR, socket: SOCKET_PATH } = walkiePaths()
 
 function connect() {
   return new Promise((resolve, reject) => {

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -1,13 +1,10 @@
 const Hyperswarm = require('hyperswarm')
 const net = require('net')
 const fs = require('fs')
-const path = require('path')
 const { deriveTopic, agentId } = require('./crypto')
 
-const WALKIE_DIR = process.env.WALKIE_DIR || path.join(process.env.HOME, '.walkie')
-const SOCKET_PATH = path.join(WALKIE_DIR, 'daemon.sock')
-const PID_FILE = path.join(WALKIE_DIR, 'daemon.pid')
-const LOG_FILE = path.join(WALKIE_DIR, 'daemon.log')
+const { walkiePaths } = require('./paths')
+const { root: WALKIE_DIR, socket: SOCKET_PATH, pid: PID_FILE, log: LOG_FILE, scope: AGENT_SCOPE } = walkiePaths()
 
 function log(...args) {
   const line = `[${new Date().toISOString()}] ${args.join(' ')}\n`
@@ -39,7 +36,7 @@ class WalkieDaemon {
     process.on('SIGTERM', () => this.shutdown())
     process.on('SIGINT', () => this.shutdown())
 
-    log(`Daemon started id=${this.id} pid=${process.pid}`)
+    log(`Daemon started id=${this.id} pid=${process.pid} scope=${AGENT_SCOPE}`)
   }
 
   // ── IPC (CLI <-> Daemon) ──────────────────────────────────────────
@@ -113,7 +110,7 @@ class WalkieDaemon {
           for (const [name, ch] of this.channels) {
             channels[name] = { peers: ch.peers.size, buffered: ch.messages.length }
           }
-          reply({ ok: true, channels, daemonId: this.id })
+          reply({ ok: true, channels, daemonId: this.id, agentScope: AGENT_SCOPE })
           break
         }
         case 'ping': {

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,0 +1,44 @@
+const os = require('os')
+const path = require('path')
+
+function sanitizeSegment(input) {
+  return String(input || 'default')
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'default'
+}
+
+function inferAgentScope(env = process.env) {
+  const explicit = env.WALKIE_AGENT_ID
+  if (explicit) return sanitizeSegment(explicit)
+
+  // Respect explicit WALKIE_DIR as a complete path selection unless scope is explicitly set.
+  if (env.WALKIE_DIR) return null
+
+  // Auto-isolate common agent runtimes so multiple agents can share one HOME
+  const inferred = env.YPI_INSTANCE_ID || env.PI_INSTANCE_ID
+  if (inferred) return sanitizeSegment(inferred)
+
+  return null
+}
+
+function walkieRoot(env = process.env) {
+  const home = env.HOME || os.homedir()
+  const base = env.WALKIE_DIR || path.join(home, '.walkie')
+  const scope = inferAgentScope(env)
+  if (!scope) return { root: base, scope: 'default' }
+  return { root: path.join(base, 'agents', scope), scope }
+}
+
+function walkiePaths(env = process.env) {
+  const { root, scope } = walkieRoot(env)
+  return {
+    root,
+    scope,
+    socket: path.join(root, 'daemon.sock'),
+    pid: path.join(root, 'daemon.pid'),
+    log: path.join(root, 'daemon.log')
+  }
+}
+
+module.exports = { walkiePaths, inferAgentScope }

--- a/test/same-home-agent-scope.js
+++ b/test/same-home-agent-scope.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+// Integration test: two logical agents sharing one WALKIE_DIR
+// but isolated by WALKIE_AGENT_ID can still communicate.
+
+const { spawn } = require('child_process')
+const net = require('net')
+const path = require('path')
+const fs = require('fs')
+
+const BASE = '/tmp/walkie-test-shared-home'
+const DAEMON_A = path.join(BASE, 'agents', 'agent-a', 'daemon.sock')
+const DAEMON_B = path.join(BASE, 'agents', 'agent-b', 'daemon.sock')
+const CLI = path.join(__dirname, '..', 'bin', 'walkie.js')
+
+function runCli(agentId, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: { ...process.env, WALKIE_DIR: BASE, WALKIE_AGENT_ID: agentId },
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    let out = ''
+    let err = ''
+    child.stdout.on('data', d => { out += d.toString() })
+    child.stderr.on('data', d => { err += d.toString() })
+    child.on('close', code => {
+      if (code === 0) resolve({ out, err })
+      else reject(new Error(`${args.join(' ')} failed (${code}): ${err || out}`))
+    })
+  })
+}
+
+function ipc(sockPath, cmd, timeout = 10000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timeout')), timeout)
+    const sock = net.connect(sockPath)
+    let buf = ''
+    sock.on('connect', () => sock.write(JSON.stringify(cmd) + '\n'))
+    sock.on('data', d => {
+      buf += d.toString()
+      const idx = buf.indexOf('\n')
+      if (idx !== -1) {
+        clearTimeout(timer)
+        sock.destroy()
+        resolve(JSON.parse(buf.slice(0, idx)))
+      }
+    })
+    sock.on('error', e => { clearTimeout(timer); reject(e) })
+  })
+}
+
+async function waitReady(sockPath, label) {
+  const start = Date.now()
+  while (Date.now() - start < 15000) {
+    try {
+      const r = await ipc(sockPath, { action: 'ping' })
+      if (r.ok) return
+    } catch {}
+    await new Promise(r => setTimeout(r, 200))
+  }
+  throw new Error(`${label} daemon failed to come up`)
+}
+
+async function run() {
+  try {
+    fs.rmSync(BASE, { recursive: true, force: true })
+  } catch {}
+
+  await runCli('agent-a', ['create', 'room', '-s', 'secret'])
+  await runCli('agent-b', ['join', 'room', '-s', 'secret'])
+
+  await waitReady(DAEMON_A, 'A')
+  await waitReady(DAEMON_B, 'B')
+
+  let foundPeers = false
+  for (let i = 0; i < 20; i++) {
+    await new Promise(r => setTimeout(r, 500))
+    const sA = await ipc(DAEMON_A, { action: 'status' })
+    const sB = await ipc(DAEMON_B, { action: 'status' })
+    const pA = sA.channels?.room?.peers || 0
+    const pB = sB.channels?.room?.peers || 0
+    if (pA > 0 && pB > 0) {
+      foundPeers = true
+      break
+    }
+  }
+
+  if (!foundPeers) {
+    throw new Error('Peers never discovered under shared WALKIE_DIR + separate WALKIE_AGENT_ID')
+  }
+
+  const send = await runCli('agent-b', ['send', 'room', 'hello from B'])
+  if (!send.out.includes('delivered to 1 peer')) {
+    throw new Error(`Unexpected send output: ${send.out || send.err}`)
+  }
+
+  const read = await runCli('agent-a', ['read', 'room', '--wait', '-t', '5'])
+  if (!read.out.includes('hello from B')) {
+    throw new Error(`Expected message not found: ${read.out || read.err}`)
+  }
+
+  console.log('PASS: shared HOME with scoped agent IDs works')
+}
+
+run().catch(err => {
+  console.error(err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## Problem
When multiple agents run on the same machine with the same HOME, walkie reuses one daemon/socket under `~/.walkie`. That causes commands to silently share identity and report `delivered to 0 peers` in real multi-agent workflows.

## What this changes
- Add `src/paths.js` for centralized daemon path resolution.
- Add scoped daemon state support:
  - explicit scope: `WALKIE_AGENT_ID`
  - auto scope in agent runtimes: `YPI_INSTANCE_ID` / `PI_INSTANCE_ID`
- Backward compatibility:
  - if `WALKIE_DIR` is explicitly set and `WALKIE_AGENT_ID` is not set, behavior stays as before.
- Expose scope in `walkie status` output (when non-default).
- Add docs for multi-agent same-machine usage.
- Add integration test `test/same-home-agent-scope.js` that verifies two logical agents share one base dir but still discover each other and exchange messages.

## Validation
- `node test/two-daemons.js`
- `node test/same-home-agent-scope.js`

Both pass locally.

## Why this is safe
This preserves single-user defaults while making multi-agent usage deterministic and collision-free without forcing users to manually manage separate HOME directories.
