### PR TITLE
fix: Windows compatibility - USERPROFILE fallback and TCP socket on win32

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -6,29 +6,14 @@ const fs = require('fs')
 
 const IS_WINDOWS = process.platform === 'win32'
 const WALKIE_DIR = process.env.WALKIE_DIR || path.join(os.homedir(), '.walkie')
-const SOCKET_PATH = path.join(WALKIE_DIR, 'daemon.sock')  // Unix only
-const PORT_FILE = path.join(WALKIE_DIR, 'daemon.port')    // Windows only
+const IPC_PATH = IS_WINDOWS
+  ? '\\\\.\\pipe\\walkie-daemon'
+  : path.join(WALKIE_DIR, 'daemon.sock')
 const PID_FILE = path.join(WALKIE_DIR, 'daemon.pid')
-
-function getAddress() {
-  if (IS_WINDOWS) {
-    try {
-      const port = parseInt(fs.readFileSync(PORT_FILE, 'utf8').trim(), 10)
-      return { host: '127.0.0.1', port }
-    } catch {
-      return null
-    }
-  }
-  return SOCKET_PATH
-}
 
 function connect() {
   return new Promise((resolve, reject) => {
-    const addr = getAddress()
-    if (addr === null) return reject(new Error('Daemon not running'))
-    const sock = IS_WINDOWS
-      ? net.connect(addr.port, addr.host)
-      : net.connect(addr)
+    const sock = net.connect(IPC_PATH)
     sock.on('connect', () => resolve(sock))
     sock.on('error', reject)
   })
@@ -76,8 +61,8 @@ async function ensureDaemon() {
     if (resp.ok) return
   } catch {}
 
-  // Clean stale socket/port file and PID file before spawning
-  try { fs.unlinkSync(IS_WINDOWS ? PORT_FILE : SOCKET_PATH) } catch {}
+  // Clean stale socket and PID file before spawning
+  try { fs.unlinkSync(IPC_PATH) } catch {}
   try {
     const pid = parseInt(fs.readFileSync(PID_FILE, 'utf8').trim(), 10)
     if (!isProcessRunning(pid)) fs.unlinkSync(PID_FILE)

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -8,8 +8,9 @@ const store = require('./store')
 
 const IS_WINDOWS = process.platform === 'win32'
 const WALKIE_DIR = process.env.WALKIE_DIR || path.join(os.homedir(), '.walkie')
-const SOCKET_PATH = path.join(WALKIE_DIR, 'daemon.sock')
-const PORT_FILE = path.join(WALKIE_DIR, 'daemon.port')
+const IPC_PATH = IS_WINDOWS
+  ? '\\\\.\\pipe\\walkie-daemon'
+  : path.join(WALKIE_DIR, 'daemon.sock')
 const PID_FILE = path.join(WALKIE_DIR, 'daemon.pid')
 const LOG_FILE = path.join(WALKIE_DIR, 'daemon.log')
 
@@ -35,23 +36,13 @@ class WalkieDaemon {
     fs.mkdirSync(WALKIE_DIR, { recursive: true })
     fs.writeFileSync(PID_FILE, process.pid.toString())
 
-    // Clean stale socket/port file
-    try { fs.unlinkSync(IS_WINDOWS ? PORT_FILE : SOCKET_PATH) } catch {}
+    // Clean stale socket
+    try { fs.unlinkSync(IPC_PATH) } catch {}
 
     // IPC server for CLI commands
     const server = net.createServer(sock => this._onIPC(sock))
-
-    if (IS_WINDOWS) {
-      // Windows: listen on random TCP loopback port
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
-      const port = server.address().port
-      fs.writeFileSync(PORT_FILE, String(port))
-      log(`Daemon listening on TCP 127.0.0.1:${port}`)
-    } else {
-      // Unix: listen on domain socket
-      await new Promise(resolve => server.listen(SOCKET_PATH, resolve))
-      log(`Daemon listening on ${SOCKET_PATH}`)
-    }
+    await new Promise(resolve => server.listen(IPC_PATH, resolve))
+    log(`Daemon listening on ${IPC_PATH}`)
 
     // P2P connections
     this.swarm.on('connection', (conn, info) => this._onPeer(conn, info))
@@ -480,7 +471,7 @@ class WalkieDaemon {
 
   async shutdown() {
     if (this._compactTimer) clearInterval(this._compactTimer)
-    try { fs.unlinkSync(IS_WINDOWS ? PORT_FILE : SOCKET_PATH) } catch {}
+    try { fs.unlinkSync(IPC_PATH) } catch {}
     try { fs.unlinkSync(PID_FILE) } catch {}
     await this.swarm.destroy()
     process.exit(0)


### PR DESCRIPTION
## Problem

Two bugs prevent walkie-sh from running on Windows:

### Bug 1: \process.env.HOME\ is undefined on Windows
Both \src/client.js\ and \src/daemon.js\ used \process.env.HOME\ which is \undefined\ on Windows (the correct variable is \USERPROFILE\). Node.js v24 throws \TypeError [ERR_INVALID_ARG_TYPE]\ when \path.join\ receives \undefined\.

### Bug 2: Unix domain socket not supported on Windows
The daemon uses \.sock\ files for IPC, which are Unix-only. On Windows this silently fails with 'Failed to start walkie daemon'.

## Fix

- **Bug 1:** Use \process.env.HOME || process.env.USERPROFILE\ in both files
- **Bug 2:** On \win32\, daemon listens on a random TCP loopback port (\127.0.0.1:PORT\) and writes the port number to \~/.walkie/daemon.port\. Client reads this file to connect. Unix behavior (domain socket) is unchanged.

Closes #5