### PR TITLE
fix: use os.homedir() in store.js for Windows compatibility

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
 
-const WALKIE_DIR = process.env.WALKIE_DIR || path.join(process.env.HOME, '.walkie')
+const WALKIE_DIR = process.env.WALKIE_DIR || path.join(os.homedir(), '.walkie')
 const MSG_DIR = path.join(WALKIE_DIR, 'messages')
 
 function sanitizeName(channel) {


### PR DESCRIPTION
## Summary

\src/store.js\ was missed in PR #6 which fixed the same \process.env.HOME\ issue in \client.js\ and \daemon.js\.

On Windows, \process.env.HOME\ is \undefined\, causing \path.join()\ to throw a \TypeError\ and crash the daemon on startup — making walkie completely unusable on Windows even after #6 was merged.

## Fix

- Added \const os = require('os')\
- Replaced \process.env.HOME\ with \os.homedir()\ in \WALKIE_DIR\ definition

This is consistent with the approach used in #6.

## Supplements

Supplements #6