### PR TITLE
Fix `agent --cli claude` posting raw stream-JSON instead of reply text

### DIFF
--- a/bin/walkie.js
+++ b/bin/walkie.js
@@ -173,13 +173,24 @@ function runClaude(prompt, sessionId, model, extraArgs) {
 
   const stdout = (result.stdout || '').trim()
   const out = { text: stdout, sessionId: null }
-  const lines = stdout.split('\n').filter(l => l.trim())
-  for (let i = lines.length - 1; i >= 0; i--) {
-    try {
-      const obj = JSON.parse(lines[i])
-      if (obj.session_id) out.sessionId = obj.session_id
-      if (obj.result !== undefined) { out.text = obj.result; break }
-    } catch {}
+
+  // `claude -p --output-format json` returns a single-line JSON array of
+  // events ([system/init, ...assistant, result]); the reply text is on the
+  // element with type "result". Older CLIs returned a single result object,
+  // and stream-json emits newline-delimited objects. Handle all three.
+  const applyEvent = (obj) => {
+    if (!obj || typeof obj !== 'object') return
+    if (obj.session_id) out.sessionId = obj.session_id
+    if (obj.type === 'result' && typeof obj.result === 'string') out.text = obj.result
+    else if (obj.result !== undefined) out.text = obj.result
+  }
+
+  let whole
+  try { whole = JSON.parse(stdout) } catch {}
+  if (Array.isArray(whole)) whole.forEach(applyEvent)
+  else if (whole && typeof whole === 'object') applyEvent(whole)
+  else for (const line of stdout.split('\n')) {
+    try { applyEvent(JSON.parse(line)) } catch {}
   }
   return out
 }


### PR DESCRIPTION
## What

Fixes the `walkie agent --cli claude` adapter, which posted **raw Claude-CLI JSON** to the channel instead of the assistant's reply text:

```
claude-bot: [{"type":"system","subtype":"init","cwd":"...","tools":[...]}, ...]
```

Fixes #13.

## Why

`runClaude()` calls `claude -p <prompt> --output-format json` and expected an object with a top-level `.result`, parsed line-by-line. The current Claude CLI returns a **single-line JSON array** of events instead:

```
$ claude -p "say PONG" --output-format json
elem types: system, rate_limit_event, assistant, result   (typeof: array, has .result: false)
```

So `JSON.parse(line)` yielded an Array, `.result`/`.session_id` were `undefined`, the loop never overrode `out.text`, and it fell back to the raw stdout dump. The reply lives on the array element with `type === "result"`.

## How

Parse the whole stdout and walk events for the `result` element. Keeps fallbacks for the legacy single-object shape and NDJSON/stream-json, so it's robust across Claude CLI versions.

## Testing

Verified the new parser against:

- **Real** `claude -p --output-format json` output → extracts `"PONG"` + `session_id` (previously dumped the full array).
- Synthetic **legacy single-object** result → `"legacy reply"`.
- Synthetic **NDJSON / stream-json** → `"stream reply"`.

All three return clean text with no JSON leakage.

## Notes (out of scope for this PR)

While testing agent-to-agent chat I also noticed: (a) no loop guard — two `walkie agent` instances respond to each other (and to `system` join events) indefinitely; and (b) occasional duplicate delivery of a single `send`. Happy to file separate issues if useful.
