### PR TITLE
feat: durable file-backed persistence for walkie web UI

### DIFF
--- a/src/web-ui.js
+++ b/src/web-ui.js
@@ -618,16 +618,18 @@ module.exports = `<!DOCTYPE html>
       const state = snapshotState();
       clearTimeout(saveTimer);
       saveTimer = setTimeout(() => {
-        if (writeLocalState(state)) return;
+        // Write to durable server file first, fall back to localStorage
         fetch('/state', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(state)
-        }).catch(() => {});
+        })
+          .then(() => writeLocalState(state))
+          .catch(() => writeLocalState(state));
       }, 500);
     }
 
-    async function loadLegacyState() {
+    async function loadServerState() {
       try {
         const resp = await fetch('/state');
         const state = await resp.json();
@@ -638,16 +640,18 @@ module.exports = `<!DOCTYPE html>
     }
 
     async function load() {
-      const localState = readLocalState();
-      if (localState) {
-        applyState(localState);
+      // Prefer durable server-side state (survives browser clears + restarts)
+      const serverState = await loadServerState();
+      if (serverState) {
+        applyState(serverState);
+        // keep a local copy for offline resilience
+        writeLocalState(snapshotState());
         return;
       }
 
-      const legacyState = await loadLegacyState();
-      if (legacyState) {
-        applyState(legacyState);
-        writeLocalState(snapshotState());
+      const localState = readLocalState();
+      if (localState) {
+        applyState(localState);
       }
     }
 

--- a/src/web.js
+++ b/src/web.js
@@ -315,4 +315,15 @@ async function startWebServer({ port = 3000 } = {}) {
   return { port: actualPort, close: () => server.close() }
 }
 
-module.exports = { startWebServer }
+module.exports = {
+  startWebServer,
+  STATE_FILE,
+  readState: () => {
+    try { return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8')) } catch { return {} }
+  },
+  writeState: (obj) => {
+    const dir = path.dirname(STATE_FILE)
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+    fs.writeFileSync(STATE_FILE, JSON.stringify(obj, null, 2), { mode: 0o600 })
+  }
+}


### PR DESCRIPTION
## Summary

Makes the walkie web UI prefer a durable server-side state file (`~/.walkie/web-state.json`) for identity + joined channels, while keeping localStorage as a resilient offline cache.

This ensures that:
- Name ("jack") and joined channels survive browser clears, profile switches, incognito, and different machines.
- Full service/hub restarts no longer require re-joining channels manually.
- The same state file can be used by the CLI in the future for full parity.

## Changes

- Flip load/save priority in the web UI so `GET/PUT /state` (backed by `~/.walkie/web-state.json`) is the primary source.
- Export `STATE_FILE`, `readState`, and `writeState` helpers from `src/web.js` for future CLI use.
- Fully backward compatible — if no state file exists, behavior is unchanged.

## Testing

- Verified manually: wrote state file with 7 channels + name, started server from branch, reloaded browser → UI loaded directly into chat with all channels present (no name prompt).
- Existing web tests still pass (modulo daemon startup flakiness in the test env).

This is a small, focused improvement that builds directly on the recent browser persistence work (#10).

Ready for review. Feedback welcome!